### PR TITLE
Speed up bootstrap __build_class__ a little bit

### DIFF
--- a/runtime/type-builtins.cpp
+++ b/runtime/type-builtins.cpp
@@ -81,9 +81,13 @@ RawObject findBuiltinTypeWithName(Thread* thread, const Object& name) {
   Runtime* runtime = thread->runtime();
   Object layout(&scope, NoneType::object());
   Object type_obj(&scope, NoneType::object());
+  Tuple layouts(&scope, runtime->layouts());
   for (int i = 0; i <= static_cast<int>(LayoutId::kLastBuiltinId); i++) {
-    layout = runtime->layoutAtSafe(static_cast<LayoutId>(i));
-    if (layout.isErrorNotFound()) continue;
+    layout = layouts.at(i);
+    if (layout == SmallInt::fromWord(0)) {
+      // Indicates an invalid LayoutId.
+      continue;
+    }
     type_obj = Layout::cast(*layout).describedType();
     if (!type_obj.isType()) continue;
     if (Type::cast(*type_obj).name() == name) {


### PR DESCRIPTION
Since we're iterating over the layouts table one by one, and the layouts table will always be at least LayoutId::kLastBuiltinId layouts long, use `Tuple::at` instead of `Runtime::layoutAtSafe`, which does a bunch of checks. This search is still linear and kind of long, though.